### PR TITLE
#32: Adopt InitialSyncer to use IPFS nodes to read info about block h…

### DIFF
--- a/Example/Example/LaunchScreen.xib
+++ b/Example/Example/LaunchScreen.xib
@@ -14,6 +14,7 @@
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
         </view>
     </objects>

--- a/WalletKit/WalletKit/Core/WalletKit.swift
+++ b/WalletKit/WalletKit/Core/WalletKit.swift
@@ -87,13 +87,13 @@ public class WalletKit {
         hdWallet = HDWallet(seed: Mnemonic.seed(mnemonic: words), network: network)
 
         stateManager = StateManager(realmFactory: realmFactory)
-        apiManager = ApiManager(apiUrl: "http://blocknode.grouvi.org/api/v1/blockchain/btc")
+        apiManager = ApiManager(apiUrl: "http://ipfs.grouvi.org/ipns/QmVefrf2xrWzGzPpERF6fRHeUTh9uVSyfHHh4cWgUBnXpq/io-hs/data/blockstore")
 
         peerGroup = PeerGroup(realmFactory: realmFactory, network: network)
         syncer = Syncer(logger: logger, realmFactory: realmFactory)
         factory = Factory()
 
-        initialSyncer = InitialSyncer(realmFactory: realmFactory, hdWallet: hdWallet, stateManager: stateManager, apiManager: apiManager, peerGroup: peerGroup)
+        initialSyncer = InitialSyncer(realmFactory: realmFactory, hdWallet: hdWallet, stateManager: stateManager, apiManager: apiManager, factory: factory, peerGroup: peerGroup, network: network)
         addressManager = AddressManager(realmFactory: realmFactory, hdWallet: hdWallet, peerGroup: peerGroup)
         progressSyncer = ProgressSyncer(realmFactory: realmFactory)
         blockSyncer = BlockSyncer(realmFactory: realmFactory, peerGroup: peerGroup)

--- a/WalletKit/WalletKit/Managers/InitialSyncer.swift
+++ b/WalletKit/WalletKit/Managers/InitialSyncer.swift
@@ -9,19 +9,25 @@ class InitialSyncer {
     private let hdWallet: HDWallet
     private let stateManager: StateManager
     private let apiManager: ApiManager
+    private let factory: Factory
     private let peerGroup: PeerGroup
+    private let network: NetworkProtocol
+    private let scheduler: ImmediateSchedulerType
 
-    init(realmFactory: RealmFactory, hdWallet: HDWallet, stateManager: StateManager, apiManager: ApiManager, peerGroup: PeerGroup) {
+    init(realmFactory: RealmFactory, hdWallet: HDWallet, stateManager: StateManager, apiManager: ApiManager, factory: Factory, peerGroup: PeerGroup, network: NetworkProtocol, scheduler: ImmediateSchedulerType = ConcurrentDispatchQueueScheduler(qos: .background)) {
         self.realmFactory = realmFactory
         self.hdWallet = hdWallet
         self.stateManager = stateManager
         self.apiManager = apiManager
+        self.factory = factory
         self.peerGroup = peerGroup
+        self.network = network
+        self.scheduler = scheduler
     }
 
     func sync() throws {
         if !stateManager.apiSynced {
-            let maxHeight = 0
+            let maxHeight = network.checkpointBlock.height
 
             let externalObservable = try fetchFromApi(external: true, maxHeight: maxHeight)
             let internalObservable = try fetchFromApi(external: false, maxHeight: maxHeight)
@@ -33,9 +39,13 @@ class InitialSyncer {
 
                         return (externalKeys + internalKeys, externalBlocks + internalBlocks)
                     })
-                    .subscribeInBackground(disposeBag: disposeBag, onNext: { [weak self] keys, blocks in
+                    .subscribeOn(scheduler)
+                    .subscribe(onNext: { [weak self] keys, blocks in
                         try? self?.handle(keys: keys, blocks: blocks)
+                    }, onError: { error in
+                        print("Initial Sync Error: \(error)")
                     })
+                    .disposed(by: disposeBag)
         } else {
             peerGroup.connect()
         }
@@ -55,34 +65,36 @@ class InitialSyncer {
         peerGroup.connect()
     }
 
-    private func fetchFromApi(external: Bool, maxHeight: Int, keys: [PublicKey] = [], blocks: [Block] = []) throws -> Observable<([PublicKey], [Block])> {
+    private func fetchFromApi(external: Bool, maxHeight: Int, lastUsedKeyIndex: Int = -1, keys: [PublicKey] = [], blocks: [Block] = []) throws -> Observable<([PublicKey], [Block])> {
         let count = keys.count
+        let gapLimit = hdWallet.gapLimit
 
-        var newKeys = [PublicKey]()
+        let newKey = try hdWallet.publicKey(index: count, external: external)
 
-        for index in count..<(count + hdWallet.gapLimit) {
-            let key = try hdWallet.publicKey(index: index, external: external)
-            newKeys.append(key)
-        }
+        return apiManager.getBlockHashes(address: newKey.address)
+                .flatMap { [unowned self] blockResponses -> Observable<([PublicKey], [Block])> in
+                    var lastUsedKeyIndex = lastUsedKeyIndex
 
-        return apiManager.getBlockHashes(addresses: newKeys.map { $0.address })
-                .flatMap { blockResponses -> Observable<([PublicKey], [Block])> in
-                    let keys = keys + newKeys
+                    if !blockResponses.isEmpty {
+                        lastUsedKeyIndex = keys.count
+                    }
 
-                    if blockResponses.isEmpty {
+                    let keys = keys + [newKey]
+
+                    if lastUsedKeyIndex < keys.count - gapLimit {
                         return Observable.just((keys, blocks))
                     } else {
                         let validResponses = blockResponses.filter { $0.height < maxHeight }
 
                         let validBlocks = validResponses.compactMap { response -> Block? in
                             if let hash = Data(hex: response.hash) {
-                                return Factory().block(withHeaderHash: Data(hash.reversed()), height: response.height)
+                                return self.factory.block(withHeaderHash: Data(hash.reversed()), height: response.height)
                             }
                             return nil
                         }
 
                         let blocks = blocks + validBlocks
-                        return try self.fetchFromApi(external: external, maxHeight: maxHeight, keys: keys, blocks: blocks)
+                        return try self.fetchFromApi(external: external, maxHeight: maxHeight, lastUsedKeyIndex: lastUsedKeyIndex, keys: keys, blocks: blocks)
                     }
                 }
     }

--- a/WalletKit/WalletKit/PeerNetwork/BitcoinRegTest.swift
+++ b/WalletKit/WalletKit/PeerNetwork/BitcoinRegTest.swift
@@ -42,4 +42,15 @@ class BitcoinRegTest: NetworkProtocol {
             ),
             height: 0)
 
+//    let checkpointBlock = Block(
+//            withHeader: BlockHeader(
+//                    version: 536870912,
+//                    previousBlockHeaderReversedHex: "5dc07110c9986c22d0cf760b68dfec769da89e465c73eb08b0b8bd7a7e9e4743",
+//                    merkleRootReversedHex: "1d9bb98732dad67e431d1983d368a389cb73dbcc495b06de7cd26c9dddccab60",
+//                    timestamp: 1536572186,
+//                    bits: 545259519,
+//                    nonce: 0
+//            ),
+//            height: 2016)
+
 }

--- a/WalletKit/WalletKitTests/Managers/InitialSyncerTests.swift
+++ b/WalletKit/WalletKitTests/Managers/InitialSyncerTests.swift
@@ -1,50 +1,90 @@
 import XCTest
 import Cuckoo
 import RealmSwift
+import RxSwift
 @testable import WalletKit
 
 class InitialSyncerTests: XCTestCase {
 
-    private var mockRealmFactory: MockRealmFactory!
     private var mockHDWallet: MockHDWallet!
     private var mockStateManager: MockStateManager!
     private var mockApiManager: MockApiManager!
+    private var mockFactory: MockFactory!
     private var mockPeerGroup: MockPeerGroup!
+    private var mockNetwork: MockNetworkProtocol!
     private var syncer: InitialSyncer!
 
     private var realm: Realm!
+    private var internalKeys: [PublicKey]!
+    private var externalKeys: [PublicKey]!
 
     override func setUp() {
         super.setUp()
 
-        mockRealmFactory = MockRealmFactory(configuration: Realm.Configuration())
-        mockHDWallet = MockHDWallet(seed: Data(), network: BitcoinTestNet(), gapLimit: 2)
-        mockStateManager = MockStateManager(realmFactory: mockRealmFactory)
-        mockApiManager = MockApiManager(apiUrl: "")
-        mockPeerGroup = MockPeerGroup(realmFactory: mockRealmFactory, network: BitcoinTestNet())
+        let mockWalletKit = MockWalletKit()
 
-        realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "TestRealm"))
-        try! realm.write { realm.deleteAll() }
+        mockHDWallet = mockWalletKit.mockHdWallet
+        mockStateManager = mockWalletKit.mockStateManager
+        mockApiManager = mockWalletKit.mockApiManager
+        mockFactory = mockWalletKit.mockFactory
+        mockPeerGroup = mockWalletKit.mockPeerGroup
+        mockNetwork = mockWalletKit.mockNetwork
+        realm = mockWalletKit.realm
 
-        stub(mockRealmFactory) { mock in
-            when(mock.realm.get).thenReturn(realm)
+        internalKeys = []
+        externalKeys = []
+        for i in 0..<5 {
+            let internalKey = PublicKey()
+            internalKey.address = "internal\(i)"
+            internalKey.external = false
+            internalKeys.append(internalKey)
+
+            let externalKey = PublicKey()
+            externalKey.address = "external\(i)"
+            externalKeys.append(externalKey)
+        }
+
+        stub(mockHDWallet) { mock in
+            when(mock.gapLimit.get).thenReturn(2)
+
+            for i in 0..<5 {
+                when(mock.publicKey(index: equal(to: i), external: equal(to: false))).thenReturn(internalKeys[i])
+                when(mock.publicKey(index: equal(to: i), external: equal(to: true))).thenReturn(externalKeys[i])
+            }
         }
         stub(mockStateManager) { mock in
             when(mock.apiSynced.get).thenReturn(false)
+            when(mock.apiSynced.set(any())).thenDoNothing()
         }
         stub(mockPeerGroup) { mock in
             when(mock.connect()).thenDoNothing()
         }
 
-        syncer = InitialSyncer(realmFactory: mockRealmFactory, hdWallet: mockHDWallet, stateManager: mockStateManager, apiManager: mockApiManager, peerGroup: mockPeerGroup)
+        let checkpointBlock = Block()
+        checkpointBlock.height = 100
+        stub(mockNetwork) { mock in
+            when(mock.checkpointBlock.get).thenReturn(checkpointBlock)
+        }
+
+        syncer = InitialSyncer(
+                realmFactory: mockWalletKit.mockRealmFactory,
+                hdWallet: mockHDWallet,
+                stateManager: mockStateManager,
+                apiManager: mockApiManager,
+                factory: mockFactory,
+                peerGroup: mockPeerGroup,
+                network: mockNetwork,
+                scheduler: MainScheduler.instance
+        )
     }
 
     override func tearDown() {
-        mockRealmFactory = nil
         mockHDWallet = nil
         mockStateManager = nil
         mockApiManager = nil
+        mockFactory = nil
         mockPeerGroup = nil
+        mockNetwork = nil
         syncer = nil
 
         realm = nil
@@ -57,15 +97,152 @@ class InitialSyncerTests: XCTestCase {
             when(mock.apiSynced.get).thenReturn(true)
         }
 
-//        try! syncer.sync()
+        try! syncer.sync()
 
-//        verify(mockPeerGroup).connect()
+        verify(mockPeerGroup).connect()
     }
 
-    func testApiSync() {
-//        try! syncer.sync()
+    func testSuccessSync() {
+        let thirdBlock = TestData.thirdBlock
+        let secondBlock = thirdBlock.previousBlock!
+        let firstBlock = secondBlock.previousBlock!
+        thirdBlock.previousBlock = nil
+        secondBlock.previousBlock = nil
+        firstBlock.previousBlock = nil
 
-//        verify(mockPeerGroup, never()).connect()
+        let externalResponse00 = BlockResponse(hash: firstBlock.reversedHeaderHashHex, height: 10)
+        let externalResponse01 = BlockResponse(hash: secondBlock.reversedHeaderHashHex, height: 12)
+        let internalResponse0 = BlockResponse(hash: thirdBlock.reversedHeaderHashHex, height: 15)
+
+        stub(mockApiManager) { mock in
+            when(mock.getBlockHashes(address: equal(to: externalKeys[0].address))).thenReturn(Observable.just([externalResponse00, externalResponse01]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[1].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[2].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[0].address))).thenReturn(Observable.just([internalResponse0]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[1].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[2].address))).thenReturn(Observable.just([]))
+        }
+
+        stub(mockFactory) { mock in
+            when(mock).block(withHeaderHash: equal(to: firstBlock.headerHash), height: equal(to: externalResponse00.height)).thenReturn(firstBlock)
+            when(mock).block(withHeaderHash: equal(to: secondBlock.headerHash), height: equal(to: externalResponse01.height)).thenReturn(secondBlock)
+            when(mock).block(withHeaderHash: equal(to: thirdBlock.headerHash), height: equal(to: internalResponse0.height)).thenReturn(thirdBlock)
+        }
+
+        try! syncer.sync()
+
+        XCTAssertEqual(realm.objects(PublicKey.self).filter("external = %@", true).count, 3)
+        XCTAssertEqual(realm.objects(PublicKey.self).filter("external = %@", false).count, 3)
+
+        XCTAssertEqual(realm.objects(Block.self).count, 3)
+        XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", externalResponse00.hash).count, 1)
+        XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", externalResponse01.hash).count, 1)
+        XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", internalResponse0.hash).count, 1)
+
+        verify(mockStateManager).apiSynced.set(true)
+        verify(mockPeerGroup).connect()
+    }
+
+    func testSuccessSync_IgnoreBlocksAfterCheckpoint() {
+        let secondBlock = TestData.secondBlock
+        let firstBlock = secondBlock.previousBlock!
+        secondBlock.previousBlock = nil
+        firstBlock.previousBlock = nil
+
+        let externalResponse0 = BlockResponse(hash: firstBlock.reversedHeaderHashHex, height: 10)
+        let externalResponse1 = BlockResponse(hash: secondBlock.reversedHeaderHashHex, height: 112)
+
+        stub(mockApiManager) { mock in
+            when(mock.getBlockHashes(address: equal(to: externalKeys[0].address))).thenReturn(Observable.just([externalResponse0]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[1].address))).thenReturn(Observable.just([externalResponse1]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[2].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[3].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[0].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[1].address))).thenReturn(Observable.just([]))
+        }
+
+        stub(mockFactory) { mock in
+            when(mock).block(withHeaderHash: equal(to: firstBlock.headerHash), height: equal(to: externalResponse0.height)).thenReturn(firstBlock)
+        }
+
+        try! syncer.sync()
+
+        XCTAssertEqual(realm.objects(PublicKey.self).filter("external = %@", true).count, 4)
+        XCTAssertEqual(realm.objects(PublicKey.self).filter("external = %@", false).count, 2)
+
+        XCTAssertEqual(realm.objects(Block.self).count, 1)
+        XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", externalResponse0.hash).count, 1)
+
+        verify(mockStateManager).apiSynced.set(true)
+        verify(mockPeerGroup).connect()
+    }
+
+    func testFailedSync_ApiError() {
+        let firstBlock = TestData.firstBlock
+        firstBlock.previousBlock = nil
+
+        let externalResponse = BlockResponse(hash: firstBlock.reversedHeaderHashHex, height: 10)
+
+        stub(mockApiManager) { mock in
+            when(mock.getBlockHashes(address: equal(to: externalKeys[0].address))).thenReturn(Observable.just([externalResponse]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[1].address))).thenReturn(Observable.error(ApiError.noConnection))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[0].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[1].address))).thenReturn(Observable.just([]))
+        }
+
+        stub(mockFactory) { mock in
+            when(mock).block(withHeaderHash: equal(to: firstBlock.headerHash), height: equal(to: externalResponse.height)).thenReturn(firstBlock)
+        }
+
+        try! syncer.sync()
+
+        XCTAssertEqual(realm.objects(PublicKey.self).count, 0)
+        XCTAssertEqual(realm.objects(Block.self).count, 0)
+
+        verify(mockStateManager, never()).apiSynced.set(true)
+        verify(mockPeerGroup, never()).connect()
+    }
+
+    func testSuccessSync_GapLimit() {
+        let thirdBlock = TestData.thirdBlock
+        let secondBlock = thirdBlock.previousBlock!
+        let firstBlock = secondBlock.previousBlock!
+        thirdBlock.previousBlock = nil
+        secondBlock.previousBlock = nil
+        firstBlock.previousBlock = nil
+
+        let response1 = BlockResponse(hash: firstBlock.reversedHeaderHashHex, height: 10)
+        let response2 = BlockResponse(hash: secondBlock.reversedHeaderHashHex, height: 12)
+        let response3 = BlockResponse(hash: thirdBlock.reversedHeaderHashHex, height: 15)
+
+        stub(mockApiManager) { mock in
+            when(mock.getBlockHashes(address: equal(to: externalKeys[0].address))).thenReturn(Observable.just([response1, response2]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[1].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[2].address))).thenReturn(Observable.just([response3]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[3].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: externalKeys[4].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[0].address))).thenReturn(Observable.just([]))
+            when(mock.getBlockHashes(address: equal(to: internalKeys[1].address))).thenReturn(Observable.just([]))
+        }
+
+        stub(mockFactory) { mock in
+            when(mock).block(withHeaderHash: equal(to: firstBlock.headerHash), height: equal(to: response1.height)).thenReturn(firstBlock)
+            when(mock).block(withHeaderHash: equal(to: secondBlock.headerHash), height: equal(to: response2.height)).thenReturn(secondBlock)
+            when(mock).block(withHeaderHash: equal(to: thirdBlock.headerHash), height: equal(to: response3.height)).thenReturn(thirdBlock)
+        }
+
+        try! syncer.sync()
+
+        XCTAssertEqual(realm.objects(PublicKey.self).filter("external = %@", true).count, 5)
+        XCTAssertEqual(realm.objects(PublicKey.self).filter("external = %@", false).count, 2)
+
+        XCTAssertEqual(realm.objects(Block.self).count, 3)
+        XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", response1.hash).count, 1)
+        XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", response2.hash).count, 1)
+        XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", response3.hash).count, 1)
+
+        verify(mockStateManager).apiSynced.set(true)
+        verify(mockPeerGroup).connect()
     }
 
 }

--- a/WalletKit/WalletKitTests/MockWalletKit.swift
+++ b/WalletKit/WalletKitTests/MockWalletKit.swift
@@ -76,7 +76,7 @@ class MockWalletKit {
         mockSyncer = MockSyncer(logger: mockLogger, realmFactory: mockRealmFactory)
         mockFactory = MockFactory()
 
-        mockInitialSyncer = MockInitialSyncer(realmFactory: mockRealmFactory, hdWallet: mockHdWallet, stateManager: mockStateManager, apiManager: mockApiManager, peerGroup: mockPeerGroup)
+        mockInitialSyncer = MockInitialSyncer(realmFactory: mockRealmFactory, hdWallet: mockHdWallet, stateManager: mockStateManager, apiManager: mockApiManager, factory: mockFactory, peerGroup: mockPeerGroup, network: mockNetwork)
         mockProgressSyncer = MockProgressSyncer(realmFactory: mockRealmFactory)
         mockAddressManager = MockAddressManager(realmFactory: mockRealmFactory, hdWallet: mockHdWallet, peerGroup: mockPeerGroup)
         mockBlockSyncer = MockBlockSyncer(realmFactory: mockRealmFactory, peerGroup: mockPeerGroup)


### PR DESCRIPTION
…ashes.

Cover InitialSyncer with unit tests.

Closes #32.