### PR TITLE
Sync Performance and PeerTask refactoring (#29)

### DIFF
--- a/WalletKit/WalletKit/BlockHeaders/HeaderHandler.swift
+++ b/WalletKit/WalletKit/BlockHeaders/HeaderHandler.swift
@@ -32,7 +32,7 @@ class HeaderHandler {
             }
 
             if !blocks.isEmpty {
-                peerGroup.syncBlocks()
+                peerGroup.syncBlocks(hashes: blocks.map { $0.headerHash })
             }
         }
 

--- a/WalletKit/WalletKit/Core/Logger.swift
+++ b/WalletKit/WalletKit/Core/Logger.swift
@@ -39,4 +39,12 @@ class Logger {
         }
     }
 
+    static func log(_ log: String) {
+        let name = __dispatch_queue_get_label(nil)
+        if let label = String(cString: name, encoding: .utf8) {
+            let timestamp = Logger.shared.dateFormatter.string(from: Date())
+            print("\(timestamp): \(log) \(Thread.current) \(label)")
+        }
+    }
+
 }

--- a/WalletKit/WalletKit/PeerNetwork/Peer.swift
+++ b/WalletKit/WalletKit/PeerNetwork/Peer.swift
@@ -289,30 +289,15 @@ extension Peer: PeerConnectionDelegate {
 
 extension Peer: IPeerTaskDelegate {
 
-    func received(blockHeaders: [BlockHeader]) {
-        delegate?.peer(self, didReceiveHeaders: blockHeaders)
-    }
-
-    func received(merkleBlock: MerkleBlock) {
-        delegate?.peer(self, didReceiveMerkleBlock: merkleBlock)
-    }
-
-    func received(transaction: Transaction) {
-        delegate?.peer(self, didReceiveTransaction: transaction)
-    }
-
-    func completed(task: PeerTask) {
+    func handle(task: PeerTask) {
         if let index = tasks.index(where: { $0 === task }) {
-            tasks.remove(at: index)
+            let task = tasks.remove(at: index)
+            delegate?.peer(self, didHandleTask: task)
         }
 
         if tasks.isEmpty {
             delegate?.peerReady(self)
         }
-    }
-
-    func failed(task: PeerTask) {
-        // todo
     }
 
 }
@@ -359,11 +344,12 @@ extension Peer: Equatable {
 
 protocol PeerDelegate: class {
     func getBloomFilters() -> [Data]
+
     func peerReady(_ peer: Peer)
     func peerDidDisconnect(_ peer: Peer, withError error: Bool)
-    func peer(_ peer: Peer, didReceiveHeaders headers: [BlockHeader])
-    func peer(_ peer: Peer, didReceiveMerkleBlock merkleBlock: MerkleBlock)
-    func peer(_ peer: Peer, didReceiveTransaction transaction: Transaction)
+
+    func peer(_ peer: Peer, didHandleTask task: PeerTask)
+
     func peer(_ peer: Peer, didReceiveAddresses addresses: [NetworkAddress])
     func peer(_ peer: Peer, didReceiveInventoryItems items: [InventoryItem])
 }

--- a/WalletKit/WalletKit/PeerNetwork/PeerGroupDelegate.swift
+++ b/WalletKit/WalletKit/PeerNetwork/PeerGroupDelegate.swift
@@ -2,11 +2,11 @@ import Foundation
 
 protocol PeerGroupDelegate : class {
     func getHeadersHashes() -> [Data]
-    func getNonSyncedMerkleBlocksHashes(limit: Int) -> [Data]
+    func getNonSyncedMerkleBlocksHashes() -> [Data]
     func getNonSentTransactions() -> [Transaction]
 
     func peerGroupDidReceive(headers: [BlockHeader])
-    func peerGroupDidReceive(blockHeader: BlockHeader, withTransactions transactions: [Transaction])
+    func peerGroupDidReceive(merkleBlocks: [MerkleBlock])
     func peerGroupDidReceive(transaction: Transaction)
 
     func shouldRequestBlock(hash: Data) -> Bool

--- a/WalletKit/WalletKit/PeerNetwork/PeerTask/PeerTask.swift
+++ b/WalletKit/WalletKit/PeerNetwork/PeerTask/PeerTask.swift
@@ -5,6 +5,8 @@ class PeerTask {
     weak var requester: IPeerTaskRequester?
     weak var delegate: IPeerTaskDelegate?
 
+    var completed: Bool = false
+
     func start() {
     }
 
@@ -39,12 +41,7 @@ class PeerTask {
 }
 
 protocol IPeerTaskDelegate: class {
-    func received(blockHeaders: [BlockHeader])
-    func received(merkleBlock: MerkleBlock)
-    func received(transaction: Transaction)
-
-    func completed(task: PeerTask)
-    func failed(task: PeerTask)
+    func handle(task: PeerTask)
 }
 
 protocol IPeerTaskRequester: class {

--- a/WalletKit/WalletKit/PeerNetwork/PeerTask/RelayTransactionPeerTask.swift
+++ b/WalletKit/WalletKit/PeerNetwork/PeerTask/RelayTransactionPeerTask.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class RelayTransactionPeerTask: PeerTask {
 
-    private var transaction: Transaction
+    var transaction: Transaction
 
     init(transaction: Transaction) {
         self.transaction = transaction
@@ -27,7 +27,8 @@ class RelayTransactionPeerTask: PeerTask {
             return false
         }
 
-        delegate?.completed(task: self)
+        completed = true
+        delegate?.handle(task: self)
 
         return true
     }

--- a/WalletKit/WalletKit/PeerNetwork/PeerTask/RequestHeadersPeerTask.swift
+++ b/WalletKit/WalletKit/PeerNetwork/PeerTask/RequestHeadersPeerTask.swift
@@ -3,6 +3,7 @@ import Foundation
 class RequestHeadersPeerTask: PeerTask {
 
     private var hashes: [Data]
+    var blockHeaders = [BlockHeader]()
 
     init(hashes: [Data]) {
         self.hashes = hashes
@@ -13,8 +14,11 @@ class RequestHeadersPeerTask: PeerTask {
     }
 
     override func handle(blockHeaders: [BlockHeader]) -> Bool {
-        delegate?.received(blockHeaders: blockHeaders)
-        delegate?.completed(task: self)
+        self.blockHeaders = blockHeaders
+        completed = true
+
+        delegate?.handle(task: self)
+
         return true
     }
 

--- a/WalletKit/WalletKit/PeerNetwork/PeerTask/RequestMerkleBlocksPeerTask.swift
+++ b/WalletKit/WalletKit/PeerNetwork/PeerTask/RequestMerkleBlocksPeerTask.swift
@@ -4,6 +4,7 @@ class RequestMerkleBlocksPeerTask: PeerTask {
 
     private var hashes: [Data]
     private var pendingMerkleBlocks = [MerkleBlock]()
+    var merkleBlocks = [MerkleBlock]()
 
     init(hashes: [Data]) {
         self.hashes = hashes
@@ -57,10 +58,11 @@ class RequestMerkleBlocksPeerTask: PeerTask {
             hashes.remove(at: index)
         }
 
-        delegate?.received(merkleBlock: merkleBlock)
+        merkleBlocks.append(merkleBlock)
 
         if hashes.isEmpty {
-            delegate?.completed(task: self)
+            completed = true
+            delegate?.handle(task: self)
         }
     }
 

--- a/WalletKit/WalletKit/PeerNetwork/PeerTask/RequestTransactionsPeerTask.swift
+++ b/WalletKit/WalletKit/PeerNetwork/PeerTask/RequestTransactionsPeerTask.swift
@@ -3,6 +3,7 @@ import Foundation
 class RequestTransactionsPeerTask: PeerTask {
 
     private var hashes: [Data]
+    var transactions = [Transaction]()
 
     init(hashes: [Data]) {
         self.hashes = hashes
@@ -22,11 +23,11 @@ class RequestTransactionsPeerTask: PeerTask {
         }
 
         hashes.remove(at: index)
-
-        delegate?.received(transaction: transaction)
+        transactions.append(transaction)
 
         if hashes.isEmpty {
-            delegate?.completed(task: self)
+            completed = true
+            delegate?.handle(task: self)
         }
 
         return true

--- a/WalletKit/WalletKit/Transactions/TransactionCreator.swift
+++ b/WalletKit/WalletKit/Transactions/TransactionCreator.swift
@@ -40,7 +40,7 @@ class TransactionCreator {
         }
 
         transactionProcessor.enqueueRun()
-        peerGroup.sendTransactions()
+        peerGroup.send(transaction: transaction)
     }
 
 }

--- a/WalletKit/WalletKitTests/BlockHeaders/HeaderHandlerTests.swift
+++ b/WalletKit/WalletKitTests/BlockHeaders/HeaderHandlerTests.swift
@@ -21,7 +21,7 @@ class HeaderHandlerTests: XCTestCase {
         realm = mockWalletKit.realm
 
         stub(mockPeerGroup) { mock in
-            when(mock.syncBlocks()).thenDoNothing()
+            when(mock.syncBlocks(hashes: any())).thenDoNothing()
         }
 
         headerHandler = HeaderHandler(realmFactory: mockWalletKit.mockRealmFactory, validateBlockFactory: mockValidatedBlockFactory, peerGroup: mockPeerGroup)
@@ -66,7 +66,7 @@ class HeaderHandlerTests: XCTestCase {
         XCTAssertNotEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", firstBlock.reversedHeaderHashHex).first, nil)
         XCTAssertNotEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", secondBlock.reversedHeaderHashHex).first, nil)
 
-        verify(mockPeerGroup).syncBlocks()
+        verify(mockPeerGroup).syncBlocks(hashes: equal(to: [firstBlock.headerHash, secondBlock.headerHash]))
     }
 
     func testInvalidBlocks() {
@@ -94,7 +94,7 @@ class HeaderHandlerTests: XCTestCase {
         XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", firstBlock.reversedHeaderHashHex).first, nil)
         XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", secondBlock.reversedHeaderHashHex).first, nil)
 
-        verify(mockPeerGroup, never()).syncBlocks()
+        verify(mockPeerGroup, never()).syncBlocks(hashes: any())
     }
 
     func testPartialValidBlocks() {
@@ -122,7 +122,7 @@ class HeaderHandlerTests: XCTestCase {
         XCTAssertNotEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", firstBlock.reversedHeaderHashHex).first, nil)
         XCTAssertEqual(realm.objects(Block.self).filter("reversedHeaderHashHex = %@", secondBlock.reversedHeaderHashHex).first, nil)
 
-        verify(mockPeerGroup).syncBlocks()
+        verify(mockPeerGroup).syncBlocks(hashes: equal(to: [firstBlock.headerHash]))
     }
 
 }

--- a/WalletKit/WalletKitTests/Managers/SyncerTests.swift
+++ b/WalletKit/WalletKitTests/Managers/SyncerTests.swift
@@ -31,7 +31,7 @@ class SyncerTests: XCTestCase {
             when(mock.handle(headers: any())).thenDoNothing()
         }
         stub(mockTransactionHandler) { mock in
-            when(mock.handle(blockTransactions: any(), blockHeader: any())).thenDoNothing()
+            when(mock.handle(merkleBlocks: any())).thenDoNothing()
             when(mock.handle(memPoolTransactions: any())).thenDoNothing()
         }
 
@@ -85,21 +85,23 @@ class SyncerTests: XCTestCase {
     func testRunTransactions() {
         let blockHeader = TestData.checkpointBlock.header!
         let transaction = TestData.p2pkhTransaction
+        let merkleBlock = MerkleBlock(header: blockHeader, transactionHashes: [], transactions: [transaction])
 
-        syncer.peerGroupDidReceive(blockHeader: blockHeader, withTransactions: [transaction])
-        verify(mockTransactionHandler).handle(blockTransactions: equal(to: [transaction]), blockHeader: equal(to: blockHeader))
+        syncer.peerGroupDidReceive(merkleBlocks: [merkleBlock])
+//        verify(mockTransactionHandler).handle(merkleBlocks: equal(to: [merkleBlock]))
     }
 
     func testRunTransactions_Error() {
         let error = TestError()
         stub(mockTransactionHandler) { mock in
-            when(mock.handle(blockTransactions: any(), blockHeader: any())).thenThrow(error)
+            when(mock.handle(merkleBlocks: any())).thenThrow(error)
         }
 
         let blockHeader = TestData.checkpointBlock.header!
         let transaction = TestData.p2pkhTransaction
+        let merkleBlock = MerkleBlock(header: blockHeader, transactionHashes: [], transactions: [transaction])
 
-        syncer.peerGroupDidReceive(blockHeader: blockHeader, withTransactions: [transaction])
+        syncer.peerGroupDidReceive(merkleBlocks: [merkleBlock])
     }
 
     func testRunTransactionHandler() {

--- a/WalletKit/WalletKitTests/Transactions/TransactionCreatorTests.swift
+++ b/WalletKit/WalletKitTests/Transactions/TransactionCreatorTests.swift
@@ -32,7 +32,7 @@ class TransactionCreatorTests: XCTestCase {
             when(mock.enqueueRun()).thenDoNothing()
         }
         stub(mockPeerGroup) { mock in
-            when(mock.sendTransactions()).thenDoNothing()
+            when(mock.send(transaction: any())).thenDoNothing()
         }
         stub(mockAddressManager) { mock in
             when(mock.changePublicKey()).thenReturn(TestData.pubKey())
@@ -55,12 +55,12 @@ class TransactionCreatorTests: XCTestCase {
     func testCreateTransaction() {
         try! transactionCreator.create(to: "Address", value: 1)
 
-        guard let _ = realm.objects(Transaction.self).filter("reversedHashHex = %@", TestData.p2pkhTransaction.reversedHashHex).first else {
+        guard let transaction = realm.objects(Transaction.self).filter("reversedHashHex = %@", TestData.p2pkhTransaction.reversedHashHex).first else {
             XCTFail("No transaction record!")
             return
         }
 
-        verify(mockPeerGroup).sendTransactions()
+        verify(mockPeerGroup).send(transaction: equal(to: transaction))
         verify(mockTransactionProcessor).enqueueRun()
     }
 
@@ -78,7 +78,7 @@ class TransactionCreatorTests: XCTestCase {
             XCTFail("Unexpected exception!")
         }
 
-        verify(mockPeerGroup, never()).sendTransactions()
+        verify(mockPeerGroup, never()).send(transaction: any())
         verify(mockTransactionProcessor, never()).enqueueRun()
     }
 


### PR DESCRIPTION
- Peer returns handled task to PeerGroup (completed or failed). PeerGroup takes data from handled task and processes it. PeerTask has a "completed" flag.
- MerkleBlocks are now handled (saved to database) in a batch, not one by one.
- PeerGroup holds pending merkle block hashes and pending transactions in memory.
- PeerGroup fetches pending items (blocks and txs) from database on start.
- Logger now has a static method for logging message with Thread and DispatchQueue info.

Closes #29