### PR TITLE
PeerHostManagerTests (#76)

### DIFF
--- a/WalletKit/WalletKit.xcodeproj/project.pbxproj
+++ b/WalletKit/WalletKit.xcodeproj/project.pbxproj
@@ -93,7 +93,9 @@
 		2FA5D60486BE522A9A7B80F8 /* AddressConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D1DAFDFD31F055B6ED11 /* AddressConverter.swift */; };
 		2FA5D67384D58067F71CD6B2 /* InputSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5DF9995FA7DD7556893F7 /* InputSigner.swift */; };
 		2FA5D6EC6F4A32E3489F89B0 /* TransactionMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D307095385625960B0A0 /* TransactionMessage.swift */; };
+		2FA5D74EDAFB77BC86918E63 /* HostDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5DE9CAB1F15B04E2C54C9 /* HostDiscovery.swift */; };
 		2FA5D9ED521660FA5EEF360E /* MerkleBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D5C9BB0E185AF72B9174 /* MerkleBlock.swift */; };
+		2FA5DB7F5BD8E25DCAF9AC83 /* PeerHostManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5DF9ADB516A45C797889D /* PeerHostManagerTests.swift */; };
 		2FA5DC1C403D74796F4131EC /* InputSignerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5DA9D7F78A26107F7209C /* InputSignerTests.swift */; };
 		2FA5DC27C4032E13E157A0D7 /* AddressConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D23A8EC7BB3569F51ABD /* AddressConverterTests.swift */; };
 		2FA5DC3D8DAD2FF85FB26C91 /* TransactionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D316DD8A722A5300002B /* TransactionHandlerTests.swift */; };
@@ -154,7 +156,7 @@
 		58AAAE352FC2FE33B4FB8F53 /* ScriptConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAABDF62BBC64C9A3363A6 /* ScriptConverterTests.swift */; };
 		58AAAF3EFFA88855ACE404FC /* PFromPKHExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAA74DF0D1F82EF49824E3 /* PFromPKHExtractorTests.swift */; };
 		D00DA94E213E86BC007F82D6 /* MemPoolMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00DA94D213E86BC007F82D6 /* MemPoolMessage.swift */; };
-		D093F45E21414CC000C5D8CD /* PeerIpManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093F45D21414CC000C5D8CD /* PeerIpManager.swift */; };
+		D093F45E21414CC000C5D8CD /* PeerHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093F45D21414CC000C5D8CD /* PeerHostManager.swift */; };
 		D31711EA20F7192400AEF61B /* PeerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31711E920F7192300AEF61B /* PeerConnection.swift */; };
 		D31711FF20F7193000AEF61B /* PingMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31711EB20F7192F00AEF61B /* PingMessage.swift */; };
 		D317120020F7193000AEF61B /* AddressMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31711EC20F7192F00AEF61B /* AddressMessage.swift */; };
@@ -289,9 +291,11 @@
 		2FA5DCD21585D41C520DF764 /* TransactionInputSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionInputSerializer.swift; sourceTree = "<group>"; };
 		2FA5DDAE64200E386070668C /* TransactionBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionBuilderTests.swift; sourceTree = "<group>"; };
 		2FA5DDED90E11DEC3647B164 /* PeerAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerAddress.swift; sourceTree = "<group>"; };
+		2FA5DE9CAB1F15B04E2C54C9 /* HostDiscovery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.swfit; path = HostDiscovery.swift; sourceTree = "<group>"; };
 		2FA5DEC34722F594F85688C0 /* TransactionOutputSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionOutputSerializer.swift; sourceTree = "<group>"; };
 		2FA5DF1470723462D2CF707B /* TransactionProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionProcessor.swift; sourceTree = "<group>"; };
 		2FA5DF9995FA7DD7556893F7 /* InputSigner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputSigner.swift; sourceTree = "<group>"; };
+		2FA5DF9ADB516A45C797889D /* PeerHostManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerHostManagerTests.swift; sourceTree = "<group>"; };
 		2FA5DFCE859758F42448A02B /* BlockHeaderSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockHeaderSerializer.swift; sourceTree = "<group>"; };
 		2FA5DFDD75C8D896B99C2ED6 /* IMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IMessage.swift; sourceTree = "<group>"; };
 		4253D028AA619104820A2FC3 /* Pods-WalletKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WalletKitTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WalletKitTests/Pods-WalletKitTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -350,7 +354,7 @@
 		83AE8083E82784076DF4BF33 /* Pods_WalletKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WalletKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		93576C99F3189FA2834EF972 /* Pods-WalletKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WalletKit.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WalletKit/Pods-WalletKit.release.xcconfig"; sourceTree = "<group>"; };
 		D00DA94D213E86BC007F82D6 /* MemPoolMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemPoolMessage.swift; sourceTree = "<group>"; };
-		D093F45D21414CC000C5D8CD /* PeerIpManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerIpManager.swift; sourceTree = "<group>"; };
+		D093F45D21414CC000C5D8CD /* PeerHostManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerHostManager.swift; sourceTree = "<group>"; };
 		D31711E920F7192300AEF61B /* PeerConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerConnection.swift; sourceTree = "<group>"; };
 		D31711EB20F7192F00AEF61B /* PingMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PingMessage.swift; sourceTree = "<group>"; };
 		D31711EC20F7192F00AEF61B /* AddressMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressMessage.swift; sourceTree = "<group>"; };
@@ -519,10 +523,11 @@
 				D31711E920F7192300AEF61B /* PeerConnection.swift */,
 				11B359E44D75610DF2841327 /* PeerGroup.swift */,
 				11B356B61A4A93F86D3637A9 /* PeerGroupDelegate.swift */,
-				D093F45D21414CC000C5D8CD /* PeerIpManager.swift */,
+				D093F45D21414CC000C5D8CD /* PeerHostManager.swift */,
 				11B356D308DCF4BB33D9F488 /* ServiceFlags.swift */,
 				11B355C0072CA13ADBAC1351 /* VarInt.swift */,
 				11B35C47D552B7AC5EA8C463 /* VarString.swift */,
+				2FA5DE9CAB1F15B04E2C54C9 /* HostDiscovery.swift */,
 			);
 			path = PeerNetwork;
 			sourceTree = "<group>";
@@ -718,6 +723,7 @@
 				58AAAAFCA9E73AD5A7AB4CA6 /* BitcoinMainNetTests.swift */,
 				58AAAEDC9D0D7BAE56C71DE0 /* BitcoinTestNetTests.swift */,
 				58AAA285EFA8FD5B4236D8CC /* BitcoinRegTestNetTests.swift */,
+				2FA5DF9ADB516A45C797889D /* PeerHostManagerTests.swift */,
 			);
 			path = PeerNetwork;
 			sourceTree = "<group>";
@@ -843,6 +849,7 @@
 				11B352462C0F682238607E64 /* Managers */,
 				D00DA94F2140E37C007F82D6 /* Messages */,
 				11B358FC5E5FE51671115A95 /* Models */,
+				58AAA80C18459F9822D75EC3 /* PeerNetwork */,
 				58AAAE8C826DAC0CB77E8521 /* Scripts */,
 				11B3582B0517A9873E63381B /* Transactions */,
 				D380FD6720FCC22800276993 /* GeneratedMocks.swift */,
@@ -850,7 +857,6 @@
 				11B3522857E30443A6A29F6F /* MockWalletKit.swift */,
 				11B358F56F6298016B1A8AFD /* TestData.swift */,
 				D380FD5F20FCC04400276993 /* Info.plist */,
-				58AAA80C18459F9822D75EC3 /* PeerNetwork */,
 				58AAA9A9A73DE22FB87CD1B1 /* MockValidatorHelper.swift */,
 			);
 			path = WalletKitTests;
@@ -1114,10 +1120,12 @@
 				"$(SRCROOT)/WalletKit/Managers/AddressManager.swift",
 				"$(SRCROOT)/WalletKit/Managers/ProgressSyncer.swift",
 				"$(SRCROOT)/WalletKit/Blocks/ValidatedBlockFactory.swift",
-				"$(SRCROOT)/WalletKit/PeerNetwork/PeerIpManager.swift",
+				"$(SRCROOT)/WalletKit/PeerNetwork/PeerHostManager.swift",
 				"$(SRCROOT)/WalletKit/BlockHeaders/Validators/IBlockValidator.swift",
 				"$(SRCROOT)/WalletKit/BlockHeaders/BlockValidatorFactory.swift",
 				"$(SRCROOT)/WalletKit/Helpers/BlockHelper.swift",
+				"$(SRCROOT)/WalletKit/PeerNetwork/HostDiscovery.swift",
+				"$(SRCROOT)/WalletKit/PeerNetwork/PeerGroup.swift",
 			);
 			name = Cuckoo;
 			outputPaths = (
@@ -1200,6 +1208,7 @@
 				58AAA3C55F225D1100102F78 /* BitcoinMainNetTests.swift in Sources */,
 				58AAA51D2E6F57CEB8947032 /* BitcoinTestNetTests.swift in Sources */,
 				58AAABF5ED93AD7DE1CE9F25 /* BitcoinRegTestNetTests.swift in Sources */,
+				2FA5DB7F5BD8E25DCAF9AC83 /* PeerHostManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1216,7 +1225,7 @@
 				D33FD6BC20F385D700EC10DB /* HDPublicKey.swift in Sources */,
 				D317121120F7193000AEF61B /* PongMessage.swift in Sources */,
 				D33FD6BD20F385D700EC10DB /* HDWallet.swift in Sources */,
-				D093F45E21414CC000C5D8CD /* PeerIpManager.swift in Sources */,
+				D093F45E21414CC000C5D8CD /* PeerHostManager.swift in Sources */,
 				11B35D0A90AD484F62B69A1B /* WalletKitPrivate.m in Sources */,
 				D33FD6C120F3863D00EC10DB /* NetworkProtocol.swift in Sources */,
 				D33FD6D520F3890700EC10DB /* WordList.swift in Sources */,
@@ -1331,6 +1340,7 @@
 				58AAAA2F6FF583897099BD98 /* LegacyTestNetDifficultyValidator.swift in Sources */,
 				58AAAD03F1F32EB8AEE1C934 /* HeaderValidator.swift in Sources */,
 				58AAA7537CABBC438DE391DF /* IBlockValidator.swift in Sources */,
+				2FA5D74EDAFB77BC86918E63 /* HostDiscovery.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WalletKit/WalletKit/Core/Logger.swift
+++ b/WalletKit/WalletKit/Core/Logger.swift
@@ -13,7 +13,7 @@ class Logger {
         String(describing: PeerConnection.self),
         String(describing: Peer.self),
         String(describing: PeerGroup.self),
-        String(describing: PeerIpManager.self),
+        String(describing: PeerHostManager.self),
         String(describing: InitialSyncer.self),
         String(describing: ProgressSyncer.self),
         ""

--- a/WalletKit/WalletKit/Core/WalletKit.swift
+++ b/WalletKit/WalletKit/Core/WalletKit.swift
@@ -30,7 +30,7 @@ public class WalletKit {
 
     let hdWallet: HDWallet
 
-    let peerIpManager: PeerIpManager
+    let peerHostManager: PeerHostManager
     let stateManager: StateManager
     let apiManager: ApiManager
     let addressManager: AddressManager
@@ -92,13 +92,13 @@ public class WalletKit {
 
         stateManager = StateManager(realmFactory: realmFactory)
         apiManager = ApiManager(apiUrl: "http://ipfs.grouvi.org/ipns/QmVefrf2xrWzGzPpERF6fRHeUTh9uVSyfHHh4cWgUBnXpq/io-hs/data/blockstore")
-        peerIpManager = PeerIpManager(network: network, realmFactory: realmFactory)
+        peerHostManager = PeerHostManager(network: network, realmFactory: realmFactory)
 
         let realm = realmFactory.realm
         let pubKeys = realm.objects(PublicKey.self)
         let filters = Array(pubKeys.map { $0.keyHash }) + Array(pubKeys.map { $0.raw! })
 
-        peerGroup = PeerGroup(network: network, peerIpManager: peerIpManager, bloomFilters: filters)
+        peerGroup = PeerGroup(network: network, peerHostManager: peerHostManager, bloomFilters: filters)
         syncer = Syncer(realmFactory: realmFactory)
         factory = Factory()
 

--- a/WalletKit/WalletKit/PeerNetwork/HostDiscovery.swift
+++ b/WalletKit/WalletKit/PeerNetwork/HostDiscovery.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+class HostDiscovery {
+    func lookup(dnsSeed: String) -> [String] {
+        let hostRef = CFHostCreateWithName(kCFAllocatorDefault, dnsSeed as CFString).takeRetainedValue()
+        let resolved = CFHostStartInfoResolution(hostRef, CFHostInfoType.addresses, nil)
+        var resolvedDarwin = DarwinBoolean(resolved)
+        let optionalDataArray = CFHostGetAddressing(hostRef, &resolvedDarwin)?.takeUnretainedValue()
+        var ips = [String]()
+
+        if let dataArray = optionalDataArray {
+            for address in (dataArray as NSArray) {
+                if let address = address as? Data {
+                    let s = address.hex.dropFirst(8).prefix(8)
+                    if let ipPart1 = UInt8(String(s.prefix(2)), radix: 16),
+                       let ipPart2 = UInt8(String(s.dropFirst(2).prefix(2)), radix: 16),
+                       let ipPart3 = UInt8(String(s.dropFirst(4).prefix(2)), radix: 16),
+                       let ipPart4 = UInt8(String(s.dropFirst(6)), radix: 16) {
+                        ips.append("\(ipPart1).\(ipPart2).\(ipPart3).\(ipPart4)")
+                    }
+                }
+            }
+
+        }
+
+        return ips
+    }
+
+}

--- a/WalletKit/WalletKitTests/MockWalletKit.swift
+++ b/WalletKit/WalletKitTests/MockWalletKit.swift
@@ -19,7 +19,7 @@ class MockWalletKit {
     let mockStateManager: MockStateManager
     let mockApiManager: MockApiManager
     let mockAddressManager: MockAddressManager
-    let mockPeerIpManager: MockPeerIpManager
+    let mockPeerHostManager: MockPeerHostManager
 
     let mockPeerGroup: MockPeerGroup
     let mockSyncer: MockSyncer
@@ -78,13 +78,13 @@ class MockWalletKit {
 
         mockStateManager = MockStateManager(realmFactory: mockRealmFactory)
         mockApiManager = MockApiManager(apiUrl: "")
-        mockPeerIpManager = MockPeerIpManager(network: mockNetwork, realmFactory: mockRealmFactory)
+        mockPeerHostManager = MockPeerHostManager(network: mockNetwork, realmFactory: mockRealmFactory)
 
-        stub(mockPeerIpManager) { mock in
+        stub(mockPeerHostManager) { mock in
             when(mock.delegate.set(any())).thenDoNothing()
         }
 
-        mockPeerGroup = MockPeerGroup(network: mockNetwork, peerIpManager: mockPeerIpManager, bloomFilters: [Data]())
+        mockPeerGroup = MockPeerGroup(network: mockNetwork, peerHostManager: mockPeerHostManager, bloomFilters: [Data]())
         mockSyncer = MockSyncer(realmFactory: mockRealmFactory)
         mockFactory = MockFactory()
 

--- a/WalletKit/WalletKitTests/PeerNetwork/PeerHostManagerTests.swift
+++ b/WalletKit/WalletKitTests/PeerNetwork/PeerHostManagerTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+import Cuckoo
+import RealmSwift
+@testable import WalletKit
+
+class PeerHostManagerTests:XCTestCase {
+
+    private var mockWalletKit: MockWalletKit!
+    private var mockPeerHostManagerDelegate: MockPeerHostManagerDelegate!
+    private var mockNetwork: MockNetworkProtocol!
+    private var mockRealmFactory: MockRealmFactory!
+    private var mockHostDiscovery: MockHostDiscovery!
+    private var queue: DispatchQueue!
+    private var dnsSeeds: [String]!
+    private var manager: PeerHostManager!
+
+    override func setUp() {
+        super.setUp()
+
+        mockWalletKit = MockWalletKit()
+        mockPeerHostManagerDelegate = MockPeerHostManagerDelegate()
+        mockNetwork = mockWalletKit.mockNetwork
+        mockRealmFactory = mockWalletKit.mockRealmFactory
+        mockHostDiscovery = MockHostDiscovery()
+        queue = DispatchQueue.main
+        dnsSeeds = ["some.seed"]
+
+        stub(mockHostDiscovery) { mock in
+            when(mock.lookup(dnsSeed: any())).thenReturn([String]())
+        }
+        stub(mockNetwork) { mock in
+            when(mock.dnsSeeds.get).thenReturn(dnsSeeds)
+        }
+
+        manager = PeerHostManager(network: mockWalletKit.mockNetwork, realmFactory: mockWalletKit.mockRealmFactory, hostDiscovery: mockHostDiscovery, queue: queue)
+    }
+
+    override func tearDown() {
+        mockWalletKit = nil
+        mockPeerHostManagerDelegate = nil
+        mockNetwork = nil
+        mockRealmFactory = nil
+        mockHostDiscovery = nil
+        queue = nil
+        manager = nil
+
+        super.tearDown()
+    }
+
+    func testPeerHost_HasFreePeerAddress() {
+        let realm = mockRealmFactory.realm
+        let peerAddress = PeerAddress(ip: "192.168.0.1", score: 0)
+
+        try! realm.write {
+            realm.add(peerAddress)
+        }
+
+        let host = manager.peerHost
+        XCTAssertEqual(host, peerAddress.ip)
+        waitForMainQueue()
+        verify(mockHostDiscovery, never()).lookup(dnsSeed: any())
+    }
+
+    func testPeerHost_HasNoFreePeerAddress() {
+        let realm = mockRealmFactory.realm
+        let peerAddress = PeerAddress(ip: "192.168.0.1", score: 0)
+
+        try! realm.write {
+            realm.add(peerAddress)
+        }
+
+        let _ = manager.peerHost
+        let host2 = manager.peerHost
+        XCTAssertEqual(host2, nil)
+        waitForMainQueue()
+        verify(mockHostDiscovery).lookup(dnsSeed: equal(to: dnsSeeds[0]))
+    }
+
+    func testPeerHost_HasNoPeerAddress() {
+        let host = manager.peerHost
+        XCTAssertEqual(host, nil)
+        waitForMainQueue()
+        verify(mockHostDiscovery).lookup(dnsSeed: equal(to: dnsSeeds[0]))
+    }
+
+    func testPeerHost_ShouldReturnAddressWithLowestScore() {
+        let realm = mockRealmFactory.realm
+        let peerAddress = PeerAddress(ip: "192.168.0.1", score: 1)
+        let peerAddress2 = PeerAddress(ip: "192.168.0.2", score: 0)
+
+        try! realm.write {
+            realm.add(peerAddress)
+            realm.add(peerAddress2)
+        }
+
+        let host = manager.peerHost
+        waitForMainQueue()
+        XCTAssertEqual(host, peerAddress2.ip)
+    }
+
+    func testHostDisconnected() {
+        let realm = mockRealmFactory.realm
+        let peerAddress = PeerAddress(ip: "192.168.0.1", score: 0)
+
+        try! realm.write {
+            realm.add(peerAddress)
+        }
+
+        manager.hostDisconnected(host: peerAddress.ip, withError: false)
+        XCTAssertEqual(peerAddress.score, 1)
+    }
+
+    func testHostDisconnected_WithError() {
+        let realm = mockRealmFactory.realm
+        let peerAddress = PeerAddress(ip: "192.168.0.1", score: 0)
+
+        try! realm.write {
+            realm.add(peerAddress)
+        }
+
+        manager.hostDisconnected(host: peerAddress.ip, withError: true)
+        XCTAssertEqual(realm.objects(PeerAddress.self).count, 0)
+    }
+
+    func testHostDisconnected_ShouldFreeHost() {
+        let realm = mockRealmFactory.realm
+        let peerAddress = PeerAddress(ip: "192.168.0.1", score: 0)
+        try! realm.write {
+            realm.add(peerAddress)
+        }
+
+        let host = manager.peerHost
+        waitForMainQueue()
+        manager.hostDisconnected(host: host!, withError: false)
+        let host2 = manager.peerHost
+        XCTAssertEqual(host, host2)
+    }
+
+    func testHostDisconnected_HostNotFound() {
+        manager.hostDisconnected(host: "192.168.0.1", withError: false)
+        let host = manager.peerHost
+        waitForMainQueue()
+        XCTAssertEqual(host, nil)
+    }
+
+    func testAddHosts() {
+        let realm = mockRealmFactory.realm
+
+        manager.addHosts(hosts: ["192.168.0.1", "192.168.0.2"])
+
+        XCTAssertEqual(realm.objects(PeerAddress.self).count, 2)
+        var peerAddress = realm.objects(PeerAddress.self).first!
+        XCTAssertEqual(peerAddress.ip, "192.168.0.1")
+        XCTAssertEqual(peerAddress.score, 0)
+        peerAddress = realm.objects(PeerAddress.self).last!
+        XCTAssertEqual(peerAddress.ip, "192.168.0.2")
+        XCTAssertEqual(peerAddress.score, 0)
+    }
+
+    func testAddHosts_ShouldAddOnlyNewHosts() {
+        let realm = mockRealmFactory.realm
+        let peerAddress = PeerAddress(ip: "192.168.0.1", score: 0)
+        try! realm.write {
+            realm.add(peerAddress)
+        }
+
+        manager.addHosts(hosts: ["192.168.0.1", "192.168.0.2"])
+
+        XCTAssertEqual(realm.objects(PeerAddress.self).count, 2)
+        var newPeerAddress = realm.objects(PeerAddress.self).first!
+        XCTAssertEqual(newPeerAddress.ip, "192.168.0.1")
+        XCTAssertEqual(newPeerAddress.score, 0)
+        newPeerAddress = realm.objects(PeerAddress.self).last!
+        XCTAssertEqual(newPeerAddress.ip, "192.168.0.2")
+        XCTAssertEqual(newPeerAddress.score, 0)
+    }
+
+    func testAddHosts_ShouldHandleDuplicates() {
+        let realm = mockRealmFactory.realm
+        manager.addHosts(hosts: ["192.168.0.1", "192.168.0.1"])
+
+        XCTAssertEqual(realm.objects(PeerAddress.self).count, 1)
+        let newPeerAddress = realm.objects(PeerAddress.self).first!
+        XCTAssertEqual(newPeerAddress.ip, "192.168.0.1")
+        XCTAssertEqual(newPeerAddress.score, 0)
+    }
+
+    func testAddHosts_ShouldCallDelegateMethod() {
+        manager.delegate = mockPeerHostManagerDelegate
+        stub(mockPeerHostManagerDelegate) { mock in
+            when(mock.newHostsAdded()).thenDoNothing()
+        }
+
+        manager.addHosts(hosts: ["192.168.0.1"])
+        verify(mockPeerHostManagerDelegate).newHostsAdded()
+    }
+
+    func testAddHosts_ShouldNotCallDelegateMethodIfNoHostAdded() {
+        manager.delegate = mockPeerHostManagerDelegate
+        stub(mockPeerHostManagerDelegate) { mock in
+            when(mock.newHostsAdded()).thenDoNothing()
+        }
+
+        manager.addHosts(hosts: [])
+        verify(mockPeerHostManagerDelegate, never()).newHostsAdded()
+    }
+
+}

--- a/WalletKit/WalletKitTests/PeerNetwork/PeerHostManagerTests.swift
+++ b/WalletKit/WalletKitTests/PeerNetwork/PeerHostManagerTests.swift
@@ -32,7 +32,7 @@ class PeerHostManagerTests:XCTestCase {
             when(mock.dnsSeeds.get).thenReturn(dnsSeeds)
         }
 
-        manager = PeerHostManager(network: mockWalletKit.mockNetwork, realmFactory: mockWalletKit.mockRealmFactory, hostDiscovery: mockHostDiscovery, queue: queue)
+        manager = PeerHostManager(network: mockWalletKit.mockNetwork, realmFactory: mockWalletKit.mockRealmFactory, hostDiscovery: mockHostDiscovery, dnsLookupQueue: queue, localQueue: queue)
     }
 
     override func tearDown() {
@@ -107,6 +107,7 @@ class PeerHostManagerTests:XCTestCase {
         }
 
         manager.hostDisconnected(host: peerAddress.ip, withError: false)
+        waitForMainQueue()
         XCTAssertEqual(peerAddress.score, 1)
     }
 
@@ -119,6 +120,7 @@ class PeerHostManagerTests:XCTestCase {
         }
 
         manager.hostDisconnected(host: peerAddress.ip, withError: true)
+        waitForMainQueue()
         XCTAssertEqual(realm.objects(PeerAddress.self).count, 0)
     }
 
@@ -132,6 +134,7 @@ class PeerHostManagerTests:XCTestCase {
         let host = manager.peerHost
         waitForMainQueue()
         manager.hostDisconnected(host: host!, withError: false)
+        waitForMainQueue()
         let host2 = manager.peerHost
         XCTAssertEqual(host, host2)
     }
@@ -147,6 +150,7 @@ class PeerHostManagerTests:XCTestCase {
         let realm = mockRealmFactory.realm
 
         manager.addHosts(hosts: ["192.168.0.1", "192.168.0.2"])
+        waitForMainQueue()
 
         XCTAssertEqual(realm.objects(PeerAddress.self).count, 2)
         var peerAddress = realm.objects(PeerAddress.self).first!
@@ -165,6 +169,7 @@ class PeerHostManagerTests:XCTestCase {
         }
 
         manager.addHosts(hosts: ["192.168.0.1", "192.168.0.2"])
+        waitForMainQueue()
 
         XCTAssertEqual(realm.objects(PeerAddress.self).count, 2)
         var newPeerAddress = realm.objects(PeerAddress.self).first!
@@ -178,6 +183,7 @@ class PeerHostManagerTests:XCTestCase {
     func testAddHosts_ShouldHandleDuplicates() {
         let realm = mockRealmFactory.realm
         manager.addHosts(hosts: ["192.168.0.1", "192.168.0.1"])
+        waitForMainQueue()
 
         XCTAssertEqual(realm.objects(PeerAddress.self).count, 1)
         let newPeerAddress = realm.objects(PeerAddress.self).first!
@@ -192,6 +198,8 @@ class PeerHostManagerTests:XCTestCase {
         }
 
         manager.addHosts(hosts: ["192.168.0.1"])
+        waitForMainQueue()
+
         verify(mockPeerHostManagerDelegate).newHostsAdded()
     }
 
@@ -202,6 +210,8 @@ class PeerHostManagerTests:XCTestCase {
         }
 
         manager.addHosts(hosts: [])
+        waitForMainQueue()
+
         verify(mockPeerHostManagerDelegate, never()).newHostsAdded()
     }
 


### PR DESCRIPTION
- Renamed PeerIpManager to PeerHostManager
- Covered PeerHostManager with tests
- Moved PeerHostManager#lookup to HostDiscovery for testability
- Fixed bug in #76 

Closes #76 