### PR TITLE
PeerHostManager bugfix #76

### DIFF
--- a/WalletKit/WalletKitTests/PeerNetwork/PeerHostManagerTests.swift
+++ b/WalletKit/WalletKitTests/PeerNetwork/PeerHostManagerTests.swift
@@ -136,6 +136,7 @@ class PeerHostManagerTests:XCTestCase {
         manager.hostDisconnected(host: host!, withError: false)
         waitForMainQueue()
         let host2 = manager.peerHost
+        waitForMainQueue()
         XCTAssertEqual(host, host2)
     }
 


### PR DESCRIPTION
- Renamed connectedHosts to usedHosts
- usedHosts are mutated within separate DispatchQueue
- collecting is renamed to 'collected'. Now, DNS lookup performs only once.