### PR TITLE
AddressManager Bugfixes (#74, #75)

### DIFF
--- a/WalletKit/WalletKit/Core/WalletKit.swift
+++ b/WalletKit/WalletKit/Core/WalletKit.swift
@@ -100,8 +100,8 @@ public class WalletKit {
         peerGroup = PeerGroup(network: network, peerHostManager: peerHostManager, bloomFilters: filters)
         factory = Factory()
 
-        initialSyncer = InitialSyncer(realmFactory: realmFactory, hdWallet: hdWallet, stateManager: stateManager, apiManager: apiManager, factory: factory, peerGroup: peerGroup, network: network)
         addressManager = AddressManager(realmFactory: realmFactory, hdWallet: hdWallet, peerGroup: peerGroup)
+        initialSyncer = InitialSyncer(realmFactory: realmFactory, hdWallet: hdWallet, stateManager: stateManager, apiManager: apiManager, addressManager: addressManager, factory: factory, peerGroup: peerGroup, network: network)
         progressSyncer = ProgressSyncer(realmFactory: realmFactory)
 
         validatedBlockFactory = ValidatedBlockFactory(realmFactory: realmFactory, factory: factory, network: network)

--- a/WalletKit/WalletKitTests/MockWalletKit.swift
+++ b/WalletKit/WalletKitTests/MockWalletKit.swift
@@ -86,9 +86,9 @@ class MockWalletKit {
         mockPeerGroup = MockPeerGroup(network: mockNetwork, peerHostManager: mockPeerHostManager, bloomFilters: [Data]())
         mockFactory = MockFactory()
 
-        mockInitialSyncer = MockInitialSyncer(realmFactory: mockRealmFactory, hdWallet: mockHdWallet, stateManager: mockStateManager, apiManager: mockApiManager, factory: mockFactory, peerGroup: mockPeerGroup, network: mockNetwork)
-        mockProgressSyncer = MockProgressSyncer(realmFactory: mockRealmFactory)
         mockAddressManager = MockAddressManager(realmFactory: mockRealmFactory, hdWallet: mockHdWallet, peerGroup: mockPeerGroup)
+        mockInitialSyncer = MockInitialSyncer(realmFactory: mockRealmFactory, hdWallet: mockHdWallet, stateManager: mockStateManager, apiManager: mockApiManager, addressManager: mockAddressManager, factory: mockFactory, peerGroup: mockPeerGroup, network: mockNetwork)
+        mockProgressSyncer = MockProgressSyncer(realmFactory: mockRealmFactory)
 
         mockValidatedBlockFactory = MockValidatedBlockFactory(realmFactory: mockRealmFactory, factory: mockFactory, network: mockNetwork)
 


### PR DESCRIPTION
- InitialSyncer now gets keys from AddressManager which in turn adds key to bloom filters in PeerGroup
- A bug in key generation with minimum unused keys gap is fixed

Closes #74 
Closes #75 